### PR TITLE
Fix PAServer output loop and missing libraries #18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,15 @@ ENV PA_SERVER_PASSWORD=$password
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yy install \
+    joe \
+    wget \
+    p7zip-full \
+    curl \
+    openssh-server \
     build-essential \
-    libcurl4-openssl-dev \
-    libcurl3-gnutls \
+    zlib1g-dev \
+    libcurl4-gnutls-dev \
+    libncurses5 \
     libgl1-mesa-dev \
     libgtk-3-bin \
     libosmesa-dev \

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-docker build . --build-arg password=securepass \
+docker build . \
+        --build-arg password=securepass \
+        --platform linux/amd64 \
 	--tag=radstudio/paserver:latest \
 	--tag=radstudio/paserver:athens \
 	--tag=radstudio/paserver:12.1 \

--- a/run-production.sh
+++ b/run-production.sh
@@ -5,5 +5,5 @@ if [ "$1" = '' ]; then
     echo "Required arguments: PAServer password";
     echo "ex: run-production.sh securepass";
 else
-    docker run -d -e PA_SERVER_PASSWORD=$1 -p 64211:64211 -p 8082:8082 radstudio/paserver:latest
+    docker run --platform linux/amd64 -d -t -e PA_SERVER_PASSWORD=$1 -p 64211:64211 -p 8082:8082 radstudio/paserver:latest
 fi

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "PAServer Password: securepass"
-docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it -e PA_SERVER_PASSWORD=securepass -p 64211:64211 -p 8082:8082 radstudio/paserver:latest
+docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --platform linux/amd64 -it -e PA_SERVER_PASSWORD=securepass -p 64211:64211 -p 8082:8082 radstudio/paserver:latest


### PR DESCRIPTION
1) PAServer requires pseudo-TTY to run detached.
2) There were missing libraries in the Dockerfile.